### PR TITLE
Add tabbed UI with title, description, README links and GitHub link

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,31 @@
 table {
     border-collapse: collapse;
 }
+.tab-content {
+    padding-top: 1rem;
+}
+#gltfTab .nav-link {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8rem;
+}
+body {
+    padding-left: 1.0rem;
+    padding-right: 1.0rem;
+}
 </style>
 </head>
 <body>
+<div class="container-fluid mt-3">
+    <a href="https://github.com/cx20/gltf-unit-test" target="_blank" rel="noopener" class="btn btn-outline-primary float-right">View on GitHub</a>
+    <h1>gltf-unit-test</h1>
+    <p>
+        This page provides unit tests for multiple glTF libraries using test models from
+        <a href="https://github.com/KhronosGroup/glTF-Asset-Generator" target="_blank" rel="noopener">glTF-Asset-Generator</a>.
+        Use the tabs below to switch between test categories. You can also limit the libraries shown
+        via the <code>engines</code> URL parameter, e.g.
+        <code>?engines=Three.js,Babylon.js,Filament,PlayCanvas</code>.
+    </p>
+</div>
 <div id="content"></div>
 
 <script src="index.js"></script>

--- a/index.js
+++ b/index.js
@@ -99,30 +99,85 @@ function queryEngines(){
 }
 
 function makeTables() {
+    var element = document.getElementById("content");
+
+    // Build Bootstrap nav tabs and tab content containers.
+    var navTabs = document.createElement('ul');
+    navTabs.className = "nav nav-tabs";
+    navTabs.setAttribute('role', 'tablist');
+    navTabs.id = "gltfTab";
+
+    var tabContent = document.createElement('div');
+    tabContent.className = "tab-content";
+    tabContent.id = "gltfTabContent";
+
+    element.appendChild(navTabs);
+    element.appendChild(tabContent);
+
+    // Allow a folder to be preselected via ?tab=FolderName
+    var preselect = null;
+    var tabRes = location.search.match(/[?&]tab=([\w\.\-]+)/);
+    if (tabRes && tabRes[1]) {
+        preselect = decodeURIComponent(tabRes[1]);
+    }
+
     for (let i = 0; i < json.length; ++i) {
         let dataSet = json[i];
-        makeTable(dataSet);
+        let isActive = preselect ? (dataSet.folder === preselect) : (i === 0);
+        makeTab(dataSet, i, isActive, navTabs, tabContent);
+    }
+
+    // Fallback: if no tab matched the preselect, activate the first.
+    if (preselect && !navTabs.querySelector('.nav-link.active')) {
+        var firstLink = navTabs.querySelector('.nav-link');
+        var firstPane = tabContent.querySelector('.tab-pane');
+        if (firstLink) firstLink.classList.add('active');
+        if (firstPane) firstPane.classList.add('show', 'active');
     }
 }
 
-function makeTable(dataSet) {
-    //console.log(dataSet.folder);
-    var element = document.getElementById("content");
-    var p = document.createElement('p');
+function makeTab(dataSet, index, isActive, navTabs, tabContent) {
     let folder = dataSet.folder;
-    p.textContent = folder;
-    element.appendChild(p);
+    let tabId = "tab-" + index + "-" + folder.replace(/[^\w\-]/g, '_');
+
+    // Nav item
+    var li = document.createElement('li');
+    li.className = "nav-item";
+    var a = document.createElement('a');
+    a.className = "nav-link" + (isActive ? " active" : "");
+    a.setAttribute('data-toggle', 'tab');
+    a.setAttribute('href', '#' + tabId);
+    a.setAttribute('role', 'tab');
+    a.textContent = folder;
+    li.appendChild(a);
+    navTabs.appendChild(li);
+
+    // Tab pane
+    var pane = document.createElement('div');
+    pane.className = "tab-pane fade" + (isActive ? " show active" : "");
+    pane.id = tabId;
+    pane.setAttribute('role', 'tabpanel');
+
+    // Link to the folder's README.md on glTF-Asset-Generator.
+    var descP = document.createElement('p');
+    descP.className = "mt-2";
+    var descA = document.createElement('a');
+    var readmeUri = ASSET_GENERATOR_REPOSITORY + "/blob/main/Output/Positive/" + folder + "/README.md";
+    descA.setAttribute('href', readmeUri);
+    descA.setAttribute('target', '_blank');
+    descA.setAttribute('rel', 'noopener');
+    descA.textContent = folder;
+    descP.appendChild(descA);
+    pane.appendChild(descP);
 
     var table = document.createElement('table');
     table.className = "table table-bordered table-sm table-striped";
 
-    var thead = makeTableHead(dataSet);
-    table.appendChild(thead);
+    table.appendChild(makeTableHead(dataSet));
+    table.appendChild(makeTableBody(dataSet));
 
-    var tbody = makeTableBody(dataSet);
-    table.appendChild(tbody);
-
-    element.appendChild(table);
+    pane.appendChild(table);
+    tabContent.appendChild(pane);
 }
 
 function makeTableHead(dataSet) {


### PR DESCRIPTION
## Summary

- Switch the model tables to Bootstrap nav-tabs grouped by glTF-Asset-Generator folder. Each folder (Accessor_Sparse, Animation_Node, ...) becomes a tab and an optional `?tab=<folder>` query parameter preselects a tab.
- Add a page title and description above the tabs explaining the purpose of the page and the `engines` URL parameter.
- Add a `View on GitHub` link in the top-right corner pointing to this repository.
- Add a link to the matching `Output/Positive/<folder>/README.md` on glTF-Asset-Generator above each table.
- Compact tab link styling (smaller font + padding) so all categories fit in ~2 rows.
- Add horizontal body padding so the tables are not flush against the viewport edges.