### PR TITLE
Fix: Change engine name to 'Khronos_glTF_Viewer' to avoid URL space issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Unit tests for multiple glTF libraries
 This repository allows you to compare any glTF library using the test model provided by [glTF-Asset-Generator](https://github.com/KhronosGroup/glTF-Asset-Generator).
 Try specifying the glTF library you want to compare in the URL argument.
 
-https://cx20.github.io/gltf-unit-test/?engines=Three.js,Babylon.js,Filament,PlayCanvas
+https://cx20.github.io/gltf-unit-test/?engines=Three.js,Babylon.js,Filament,PlayCanvas,Khronos_glTF_Viewer
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ let engines = [{
     name: 'minimal-gltf-loader',
     path: ENGINE_BASE_URL + '/examples/minimal-gltf-loader/index.html'
 }, {
-    name: 'Khronos glTF Viewer',
+    name: 'Khronos_glTF_Viewer',
     path: ENGINE_BASE_URL + '/examples/khronos-gltf-rv/index.html'
 }, {
     name: 'ClayGL',


### PR DESCRIPTION
This pull request updates the glTF unit test project to add support for the "Khronos_glTF_Viewer" engine and ensures consistent naming across the documentation and code. The most important changes are:

**Support for new engine:**

* Added "Khronos_glTF_Viewer" as a selectable engine in the example URL in `README.md`, allowing users to include it in their comparisons.

**Consistency improvements:**

* Updated the engine name from "Khronos glTF Viewer" to "Khronos_glTF_Viewer" in the `engines` array in `index.js` to match the new naming convention and ensure consistency with the URL parameter.